### PR TITLE
Set up CMake build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 
 # Makefile object
 /src/libs/build-stamp
+/*build*
 
 /morris_meth/ipch
 /morris_meth/Debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ services:
 compiler:
   - gcc
 
-addons:
-  apt:
-    packages:
-      - gfortran
-      - liblapack-dev
-
 jobs:
   include:
     - name: "pestpp-opt tests"
@@ -61,10 +55,9 @@ jobs:
         TEST_DIR="benchmarks"
 
 before_script:
-  - cd src
-  - rm -r -f ../bin/linux/
-  - make clean
-  - STATIC=no make -j2
+  - mkdir build && cd build
+  - cmake -DCMAKE_BUILD_TYPE=Release ..
+  - make -j2
   - make install
   - cd ..
   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,101 @@
+# This is the top-level CMake file for PEST++
+cmake_minimum_required(VERSION 3.9)
+
+# Get PESTPP_VERSION from common source header
+file(READ "${CMAKE_SOURCE_DIR}/src/libs/common/config_os.h" _file)
+string(REGEX MATCH "PESTPP_VERSION \"([0-9\.]+)\"" _ ${_file})
+set(PESTPP_VERSION ${CMAKE_MATCH_1})
+if("${PESTPP_VERSION}" STREQUAL "")
+  message(SEND_ERROR
+    "Could not find PESTPP_VERSION in src/libs/common/config_os.h")
+endif()
+
+project(PESTPP
+  VERSION ${PESTPP_VERSION}
+  LANGUAGES CXX)
+
+# Fortran is not required (anymore), but can be enabled using either:
+#  1. ENABLE_Fortran=ON and use whatever default compiler is available
+#  2. CMAKE_Fortran_COMPILER=ifort (or other compiler)
+if(DEFINED ENABLE_Fortran)
+  set(_default_ENABLE_Fortran ${ENABLE_Fortran})
+else()
+  if(DEFINED CMAKE_Fortran_COMPILER)
+    set(_default_ENABLE_Fortran ON)
+  else()
+    set(_default_ENABLE_Fortran OFF)
+  endif()
+endif()
+option(ENABLE_Fortran "Enable Fortran in PEST++" ${_default_ENABLE_Fortran})
+if(ENABLE_Fortran)
+  enable_language(Fortran)
+  find_package(LAPACK REQUIRED)
+  message(STATUS "BLA_VENDOR=${BLA_VENDOR}")
+  message(STATUS "BLAS_LIBRARIES=${BLAS_LIBRARIES}")
+  message(STATUS "LAPACK_LIBRARIES=${LAPACK_LIBRARIES}")
+  set(Fortran_ENABLED TRUE)
+else()
+  set(Fortran_ENABLED FALSE)
+endif()
+
+find_package(Threads REQUIRED)
+
+# Ensure C++11 is used
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Global warning flags
+set(PESTPP_CXX_WARN_FLAGS "${PESTPP_CXX_WARN_FLAGS}"
+  CACHE STRING "C++ flags used to compile PEST++ targets")
+
+option(BUILD_SHARED_LIBS "Build PEST++ shared (default is static)" OFF)
+message(STATUS "BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}")
+
+# Default install directory is custom layout in source dir ./bin
+if(WIN32)
+  if("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
+    set(_osdir "iwin")
+  else()
+    set(_osdir "win")
+  endif()
+elseif(APPLE)
+  set(_osdir "mac")
+elseif(UNIX)
+  set(_osdir "linux")
+else()
+  message(SEND_ERROR "Could not detect OS")
+endif()
+set(_default_INSTALL_PREFIX "${PESTPP_SOURCE_DIR}/bin/${_osdir}")
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${_default_INSTALL_PREFIX}"
+    CACHE PATH "Default custom install prefix" FORCE)
+endif()
+
+if("${CMAKE_INSTALL_PREFIX}" STREQUAL "${_default_INSTALL_PREFIX}")
+  if(BUILD_SHARED_LIBS AND UNIX)
+    message(WARNING
+      "Shared libraries may not be found correctly when installed to default "
+      "source dir, unless LD_LIBRARY_PATH is also set to that path. "
+      "It is advised to use BUILD_SHARED_LIBS=OFF or set "
+      "CMAKE_INSTALL_PREFIX to a common system prefix.")
+  endif()
+  message(STATUS
+    "Install location is default, to local source tree: "
+    "${CMAKE_INSTALL_PREFIX}")
+  set(BINDIR "${CMAKE_INSTALL_PREFIX}")
+  set(LIBDIR "${CMAKE_INSTALL_PREFIX}")
+  # Remove old files before installing new ones
+  install(CODE
+    "MESSAGE(\"Cleaning up previous files in ${CMAKE_INSTALL_PREFIX}\")")
+  install(CODE "file(REMOVE_RECURSE ${CMAKE_INSTALL_PREFIX})")
+else()
+  message(STATUS
+    "Install prefix set by CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
+  set(BINDIR "bin")
+  set(LIBDIR "lib")
+endif()
+
+# Build main targets in src
+add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -23,13 +23,9 @@ The lastest PEST++ manual is available [here](https://github.com/jtwhite79/pestp
 * [mac OS](https://github.com/usgs/pestpp/tree/master/bin/mac).  Direct zip download [here](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/usgs/pestpp/tree/master/bin/mac)
 
 ## Compiling
-The master branch includes a Visual Studio project, as well as makefiles for linux and mac. The suite has been succcessfully compiled with gcc (g++) 4,5,6 and 7 on ubuntu, fedora, centos, and on slurm/MPI clusters - to use gcc, you must C++11 support (if using gcc 4, only gcc4.9 has this).  Then, in the `src` directory:
+The develop branch includes a Visual Studio project, as well as CMake files for cross-compilation on all operating systems.
 
-`>>>make clean`
-
-`>>>STATIC=no make install`
-
-This should put the compiled binaries in the `bin/linux` directory.  See the `.travis.yml` file for an example
+See details [here](documentation/cmake.md) to compile using CMake.
 
 ## Overview
 The PEST++ software suite includes several stand-alone tools for model-independent (non-intrusive) computer model parameter estimation and uncertainty analysis.  Codes include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,12 @@
+image: Visual Studio 2017
+platform: x64
+
 environment:
   
   matrix:
     - PYTHON_VERSION: "3.6"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
 
-platform:
-    - x64
 clone_depth: 1
 shallow_clone: true
 
@@ -23,6 +24,14 @@ init:
   - echo %PYTHON_VERSION% %CONDA_INSTALL_LOCN%
 
 install:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - mkdir build
+  - cd build
+  - cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
+  - cmake --build .
+  - cmake --install .
+  - cd ..
+
   - set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%;
   - set PYTHONUNBUFFERED=1
   # for msinttypes and newer stuff
@@ -35,10 +44,8 @@ install:
   - call %CONDA_INSTALL_LOCN%\scripts\activate
   - conda info -a
 
-  - conda install --yes python=%PYTHON_VERSION% pip numpy scipy pandas nose matplotlib
-  - pip install coveralls
-  - pip install pyshp
-  - pip install nose-timer
+  - conda install --yes python=%PYTHON_VERSION% pip numpy scipy pandas matplotlib nose
+  - pip install coveralls pyshp nose-timer
   - pip install git+https://github.com/modflowpy/flopy.git@develop
   - pip install git+https://github.com/jtwhite79/pyemu.git@develop
   # Show the installed packages + versions

--- a/documentation/cmake.md
+++ b/documentation/cmake.md
@@ -1,0 +1,116 @@
+# Building PEST++ with CMake
+
+## Introduction
+
+CMake is a cross-platform tool used to build software on most operating systems and compilers. CMake can be installed using one of several methods, such as from [official sources](https://cmake.org/download/), from Anaconda/Miniconda (`conda install cmake`), or from PyPI (`pip install cmake`). Newest versions are recommended, with a minimum 3.9 enforced for PEST++.
+
+## General guidance
+
+The normal approach to compile a project with CMake is outside of the source tree, in a directory named `build` (or similar). Therefore, before running `cmake`, ensure this is done in an empty directory:
+
+    mkdir build
+    cd build
+    cmake ..
+
+Variables and options are passed to CMake using `-D<var>=<value>` options to the command-line interface.
+
+* `BUILD_SHARED_LIBS=OFF` - Static libraries are built by default, but shared libraries can be enabled by setting value to `ON`.
+* `CMAKE_BUILD_TYPE` - Specify the build type for single-configuration generators, including Makefile and Ninja. Possible values are `Debug`, `Release`, `RelWithDebInfo`, or `MinSizeRel`.
+* `CMAKE_INSTALL_PREFIX` - Default is to install executable to the project source tree in `./bin`, but a different prefix (such as `$HOME/.local`) can be specified.
+* `CMAKE_CXX_COMPILER` - Normally this is detected, but it can be overridden to use a different C++ compiler.
+* `CMAKE_Fortran_COMPILER` - If specified (such as `ifort`), this enables Fortran support to build additional targets.
+* `ENABLE_Fortran=OFF` - If set `ON`, enable Fortran support, using default Fortran compiler to build additional targets.
+
+## Linux and macOS
+
+If a generator (`-G`) is not specified, the default for Linux is Makefile, which simple to use.
+
+### Basic usage
+
+Create an empty directory:
+
+    mkdir build && cd build
+
+Configure a release build using the default C++ compiler:
+
+    cmake -DCMAKE_BUILD_TYPE=Release ..
+
+Build all targets with (e.g.) 8 cores:
+
+    make -j8
+
+Or build a single executable, and any dependencies for that target:
+
+    make pestpp-ies
+
+Install to desired location, which will normally be in `./bin/linux` or `./bin/mac`:
+
+    make install
+
+### Configure for different compilers
+
+The configure step can be re-run, but CMake usually requires a "clean" build directory when switching compilers:
+
+    cd .. && rm -rf build && mkdir build && cd build
+
+To configure with Intel C++ and Fortran:
+
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icpc -DCMAKE_Fortran_COMPILER=ifort ..
+
+Or Clang++ version 8:
+
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=clang++-8 ..
+
+## Windows
+
+### Using Ninja
+
+[Ninja](https://ninja-build.org/) is a fast generator that works well with CMake and Visual Studio compilers, and similarly can be installed from [official sources](https://github.com/ninja-build/ninja/releases), from Anaconda/Miniconda (`conda install ninja`), or from PyPI (`pip install cmake`).
+
+Configuring with a specified generator:
+
+    cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
+
+Build normally takes advantage of as many cores as are available:
+
+    cmake --build .
+
+And install:
+
+    cmake --install .
+
+Build and install steps can be combined with one command:
+
+    cmake --build . --target install
+
+### Visual Studio
+
+Configure using Visual Studio 2019:
+
+    cmake -G"Visual Studio 16 2019" -A Win64 ..
+
+Or configure using Visual Studio 2017:
+
+    cmake -G"Visual Studio 15 2017 Win64" ..
+
+Build all targets with "Release" configuration:
+
+    cmake --build . --config Release
+
+Or choose only one target to compile:
+
+    cmake --build . --config Release --target pestpp-ies
+
+Install executables:
+
+    cmake --build . --config Release --target install
+
+### Intel C++/Fortran
+
+To configure using Intel C++/Fortran, use "NMake Makefiles" generator:
+
+    cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icl -DCMAKE_Fortran_COMPILER=ifort ..
+
+Then follow similar steps to build and install:
+
+    cmake --build . --config Release --target install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,5 @@
+# This CMake file is part of PEST++
+
+add_subdirectory(libs)
+add_subdirectory(programs)
+add_subdirectory(utilities)

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -1,0 +1,29 @@
+# This CMake file is part of PEST++
+
+# Create a header-only target for Eigen that other targets can use
+add_library(Eigen INTERFACE)
+
+target_include_directories(Eigen INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/Eigen")
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # silence these warnings when building CXX objects
+  target_compile_options(Eigen
+    INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>
+  )
+endif()
+
+if(WIN32)
+  add_compile_definitions(_WIN32_WINNT=0x0600)
+endif()
+
+add_subdirectory(common)
+add_subdirectory(opt)
+add_subdirectory(pestpp_common)
+add_subdirectory(run_managers)
+
+if(Fortran_ENABLED)
+  # These libraries are not linked anywhere
+  # add_subdirectory(mio)
+  # add_subdirectory(propack)
+endif()

--- a/src/libs/common/CMakeLists.txt
+++ b/src/libs/common/CMakeLists.txt
@@ -1,0 +1,32 @@
+# This CMake file is part of PEST++
+
+add_library(common
+  fortran_wrappers.cpp
+  network_package.cpp
+  network_wrapper.cpp
+  pest_error.cpp
+  system_variables.cpp
+  Transformable.cpp
+  utilities.cpp
+)
+
+target_include_directories(common INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+target_compile_options(common PRIVATE ${PESTPP_CXX_WARN_FLAGS})
+
+target_link_libraries(common
+  Eigen
+  Threads::Threads
+)
+
+target_compile_features(common PUBLIC cxx_std_11)
+set_target_properties(common PROPERTIES CXX_EXTENSIONS OFF)
+
+if(WIN32)
+  # Winsock library required
+  target_link_libraries(common ws2_32)
+endif()
+
+if(BUILD_SHARED_LIBS)
+  install(TARGETS common LIBRARY DESTINATION ${LIBDIR})
+endif()

--- a/src/libs/mio/CMakeLists.txt
+++ b/src/libs/mio/CMakeLists.txt
@@ -1,0 +1,9 @@
+# This CMake file is part of PEST++
+
+add_library(mio mio.F90)
+
+target_link_libraries(mio common)
+
+if(BUILD_SHARED_LIBS)
+  install(TARGETS mio LIBRARY DESTINATION ${LIBDIR})
+endif()

--- a/src/libs/opt/CMakeLists.txt
+++ b/src/libs/opt/CMakeLists.txt
@@ -1,0 +1,140 @@
+# This CMake file is part of PEST++
+
+# This library is only linked by pestpp-opt, so force it static
+add_library(opt STATIC
+  CbcOrClpParam.cpp
+  Clp_ampl.cpp
+  ClpCholeskyBase.cpp
+  ClpCholeskyDense.cpp
+  ClpCholeskyTaucs.cpp
+  ClpCholeskyWssmp.cpp
+  ClpCholeskyWssmpKKT.cpp
+  Clp_C_Interface.cpp
+  ClpConstraint.cpp
+  ClpConstraintLinear.cpp
+  ClpConstraintQuadratic.cpp
+  ClpDualRowDantzig.cpp
+  ClpDualRowPivot.cpp
+  ClpDualRowSteepest.cpp
+  ClpDummyMatrix.cpp
+  ClpDynamicExampleMatrix.cpp
+  ClpDynamicMatrix.cpp
+  ClpEventHandler.cpp
+  ClpFactorization.cpp
+  ClpGubDynamicMatrix.cpp
+  ClpGubMatrix.cpp
+  ClpHelperFunctions.cpp
+  ClpInterior.cpp
+  ClpLinearObjective.cpp
+  ClpLsqr.cpp
+  # ClpMain.cpp -- remove for building library
+  ClpMatrixBase.cpp
+  ClpMessage.cpp
+  ClpModel.cpp
+  ClpNetworkBasis.cpp
+  ClpNetworkMatrix.cpp
+  ClpNode.cpp
+  ClpNonLinearCost.cpp
+  ClpObjective.cpp
+  ClpPackedMatrix.cpp
+  ClpPdcoBase.cpp
+  ClpPdco.cpp
+  ClpPlusMinusOneMatrix.cpp
+  ClpPredictorCorrector.cpp
+  ClpPresolve.cpp
+  ClpPrimalColumnDantzig.cpp
+  ClpPrimalColumnPivot.cpp
+  ClpPrimalColumnSteepest.cpp
+  ClpQuadraticObjective.cpp
+  ClpSimplex.cpp
+  ClpSimplexDual.cpp
+  ClpSimplexNonlinear.cpp
+  ClpSimplexOther.cpp
+  ClpSimplexPrimal.cpp
+  ClpSolve.cpp
+  ClpSolver.cpp
+  CoinAbcBaseFactorization1.cpp
+  CoinAbcBaseFactorization2.cpp
+  CoinAbcBaseFactorization3.cpp
+  CoinAbcBaseFactorization4.cpp
+  CoinAbcBaseFactorization5.cpp
+  CoinAlloc.cpp
+  CoinBuild.cpp
+  CoinDenseFactorization.cpp
+  CoinDenseVector.cpp
+  CoinError.cpp
+  CoinFactorization1.cpp
+  CoinFactorization2.cpp
+  CoinFactorization3.cpp
+  CoinFactorization4.cpp
+  CoinFileIO.cpp
+  CoinFinite.cpp
+  CoinIndexedVector.cpp
+  CoinLpIO.cpp
+  CoinMessage.cpp
+  CoinMessageHandler.cpp
+  CoinModel.cpp
+  CoinModelUseful2.cpp
+  CoinModelUseful.cpp
+  CoinMpsIO.cpp
+  CoinOslFactorization2.cpp
+  CoinOslFactorization3.cpp
+  CoinOslFactorization.cpp
+  CoinPackedMatrix.cpp
+  CoinPackedVectorBase.cpp
+  CoinPackedVector.cpp
+  CoinParam.cpp
+  CoinParamUtils.cpp
+  CoinPostsolveMatrix.cpp
+  CoinPrePostsolveMatrix.cpp
+  CoinPresolveDoubleton.cpp
+  CoinPresolveDual.cpp
+  CoinPresolveDupcol.cpp
+  CoinPresolveEmpty.cpp
+  CoinPresolveFixed.cpp
+  CoinPresolveForcing.cpp
+  CoinPresolveHelperFunctions.cpp
+  CoinPresolveImpliedFree.cpp
+  CoinPresolveIsolated.cpp
+  CoinPresolveMatrix.cpp
+  CoinPresolveMonitor.cpp
+  CoinPresolvePsdebug.cpp
+  CoinPresolveSingleton.cpp
+  CoinPresolveSubst.cpp
+  CoinPresolveTighten.cpp
+  CoinPresolveTripleton.cpp
+  CoinPresolveUseless.cpp
+  CoinPresolveZeros.cpp
+  CoinRational.cpp
+  CoinSearchTree.cpp
+  CoinShallowPackedVector.cpp
+  CoinSimpFactorization.cpp
+  CoinSnapshot.cpp
+  CoinStructuredModel.cpp
+  CoinWarmStartBasis.cpp
+  CoinWarmStartDual.cpp
+  CoinWarmStartPrimalDual.cpp
+  CoinWarmStartVector.cpp
+  Idiot.cpp
+  IdiSolve.cpp
+  sequential_lp.cpp
+)
+
+target_include_directories(opt INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+target_compile_definitions(opt PRIVATE
+  HAVE_CMATH
+  HAVE_FLOAT_H
+  USE_EKKWSSMP
+)
+
+if(WIN32)
+  target_compile_definitions(opt PRIVATE
+    CLP_BUILD
+    _CRT_SECURE_NO_WARNINGS
+  )
+endif()
+
+target_compile_options(opt PRIVATE ${PESTPP_CXX_WARN_FLAGS})
+
+target_link_libraries(opt pestpp_com)

--- a/src/libs/pestpp_common/CMakeLists.txt
+++ b/src/libs/pestpp_common/CMakeLists.txt
@@ -1,0 +1,48 @@
+# This CMake file is part of PEST++
+
+# This library depends on rm_abstract; avoid cyclic dependency
+add_library(pestpp_com STATIC
+  constraints.cpp
+  covariance.cpp
+  DifferentialEvolution.cpp
+  eigen_tools.cpp
+  Ensemble.cpp
+  EnsembleMethodUtils.cpp
+  EnsembleSmoother.cpp
+  FileManager.cpp
+  Jacobian_1to1.cpp
+  Jacobian.cpp
+  linear_analysis.cpp
+  Localizer.cpp
+  logger.cpp
+  ModelRunPP.cpp
+  ObjectiveFunc.cpp
+  OutputFileWriter.cpp
+  ParamTransformSeq.cpp
+  PerformanceLog.cpp
+  Pest.cpp
+  pest_data_structs.cpp
+  PriorInformation.cpp
+  QSqrtMatrix.cpp
+  Regularization.cpp
+  RestartController.cpp
+  SVDASolver.cpp
+  SVDPackage.cpp
+  SVD_PROPACK.cpp
+  SVDSolver.cpp
+  TerminationController.cpp
+  Transformation.cpp
+)
+
+target_include_directories(pestpp_com INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+target_compile_options(pestpp_com PRIVATE ${PESTPP_CXX_WARN_FLAGS})
+
+target_link_libraries(pestpp_com
+  common
+  rm_abstract
+)
+
+if(BUILD_SHARED_LIBS)
+  set_property(TARGET pestpp_com PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()

--- a/src/libs/propack/CMakeLists.txt
+++ b/src/libs/propack/CMakeLists.txt
@@ -1,0 +1,22 @@
+# This CMake file is part of PEST++
+
+add_library(propack
+  dgemm_ovwr.F
+  dgetu0.F
+  dlanbpro.F
+  dlansvd.F
+  dmgs.pentium.F
+  dreorth.F
+  dritzvec.F
+  dsafescal.F
+  propack_misc.for
+)
+
+target_link_libraries(propack ${LAPACK_LIBRARIES})
+
+if(BUILD_SHARED_LIBS)
+  install(TARGETS propack LIBRARY DESTINATION ${LIBDIR})
+else()
+  # pthread required for static linking
+  target_link_libraries(propack Threads::Threads)
+endif()

--- a/src/libs/run_managers/CMakeLists.txt
+++ b/src/libs/run_managers/CMakeLists.txt
@@ -1,0 +1,10 @@
+# This CMake file is part of PEST++
+
+add_subdirectory(abstract_base)
+add_subdirectory(external)
+add_subdirectory(serial)
+add_subdirectory(yamr)
+
+if(Fortran_ENABLED)
+  add_subdirectory(wrappers)
+endif()

--- a/src/libs/run_managers/abstract_base/CMakeLists.txt
+++ b/src/libs/run_managers/abstract_base/CMakeLists.txt
@@ -1,0 +1,21 @@
+# This CMake file is part of PEST++
+
+# This library depends on pestpp_com; avoid cyclic dependency
+add_library(rm_abstract STATIC
+  debug.cpp
+  linpackc.cpp
+  model_interface.cpp
+  RunManagerAbstract.cpp
+  RunStorage.cpp
+  Serializeation.cpp
+)
+
+target_include_directories(rm_abstract INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+target_compile_options(rm_abstract PRIVATE ${PESTPP_CXX_WARN_FLAGS})
+
+target_link_libraries(rm_abstract pestpp_com)
+
+if(BUILD_SHARED_LIBS)
+  set_property(TARGET rm_abstract PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()

--- a/src/libs/run_managers/external/CMakeLists.txt
+++ b/src/libs/run_managers/external/CMakeLists.txt
@@ -1,0 +1,13 @@
+# This CMake file is part of PEST++
+
+add_library(rm_external RunManagerExternal.cpp)
+
+target_include_directories(rm_external INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+target_compile_options(rm_external PRIVATE ${PESTPP_CXX_WARN_FLAGS})
+
+target_link_libraries(rm_external rm_abstract)
+
+if(BUILD_SHARED_LIBS)
+  install(TARGETS rm_external LIBRARY DESTINATION ${LIBDIR})
+endif()

--- a/src/libs/run_managers/serial/CMakeLists.txt
+++ b/src/libs/run_managers/serial/CMakeLists.txt
@@ -1,0 +1,13 @@
+# This CMake file is part of PEST++
+
+add_library(rm_serial RunManagerSerial.cpp)
+
+target_include_directories(rm_serial INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+target_compile_options(rm_serial PRIVATE ${PESTPP_CXX_WARN_FLAGS})
+
+target_link_libraries(rm_serial rm_abstract)
+
+if(BUILD_SHARED_LIBS)
+  install(TARGETS rm_serial LIBRARY DESTINATION ${LIBDIR})
+endif()

--- a/src/libs/run_managers/wrappers/CMakeLists.txt
+++ b/src/libs/run_managers/wrappers/CMakeLists.txt
@@ -1,0 +1,18 @@
+# This CMake file is part of PEST++
+
+# This library is only linked by pestpp-pso, so force it static
+add_library(rm_wrappers STATIC
+  RunManagerCWrapper.cpp
+  RunManagerFortranWrapper.cpp
+)
+
+if(WIN32)
+  target_compile_definitions(rm_wrappers PRIVATE _SCL_SECURE_NO_WARNINGS)
+endif()
+
+target_compile_options(rm_wrappers PRIVATE ${PESTPP_CXX_WARN_FLAGS})
+
+target_link_libraries(rm_wrappers
+  rm_serial
+  rm_yamr
+)

--- a/src/libs/run_managers/yamr/CMakeLists.txt
+++ b/src/libs/run_managers/yamr/CMakeLists.txt
@@ -1,0 +1,16 @@
+# This CMake file is part of PEST++
+
+add_library(rm_yamr
+  PantherAgent.cpp
+  RunManagerPanther.cpp
+)
+
+target_include_directories(rm_yamr INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+target_compile_options(rm_yamr PRIVATE ${PESTPP_CXX_WARN_FLAGS})
+
+target_link_libraries(rm_yamr rm_abstract)
+
+if(BUILD_SHARED_LIBS)
+  install(TARGETS rm_yamr LIBRARY DESTINATION ${LIBDIR})
+endif()

--- a/src/programs/CMakeLists.txt
+++ b/src/programs/CMakeLists.txt
@@ -1,0 +1,10 @@
+# This CMake file is part of PEST++
+
+add_subdirectory(gsa)
+add_subdirectory(pest++)
+add_subdirectory(pestpp-ies)
+add_subdirectory(pestpp-opt)
+add_subdirectory(sweep)
+if(Fortran_ENABLED)
+  add_subdirectory(pestpp-pso)
+endif()

--- a/src/programs/gsa/CMakeLists.txt
+++ b/src/programs/gsa/CMakeLists.txt
@@ -1,0 +1,20 @@
+# This CMake file is part of PEST++
+
+add_executable(pestpp-sen
+  GsaAbstractBase.cpp
+  main.cpp
+  MorrisMethod.cpp
+  PooledVariance.cpp
+  sobol.cpp
+  Stats.cpp
+  # TornadoPlot.cpp
+)
+
+target_compile_options(pestpp-sen PRIVATE ${PESTPP_CXX_WARN_FLAGS})
+
+target_link_libraries(pestpp-sen
+  rm_serial
+  rm_yamr
+)
+
+install(TARGETS pestpp-sen RUNTIME DESTINATION ${BINDIR})

--- a/src/programs/pest++/CMakeLists.txt
+++ b/src/programs/pest++/CMakeLists.txt
@@ -1,0 +1,13 @@
+# This CMake file is part of PEST++
+
+add_executable(pestpp-glm pest++.cpp)
+
+target_compile_options(pestpp-glm PRIVATE ${PESTPP_CXX_WARN_FLAGS})
+
+target_link_libraries(pestpp-glm
+  rm_external
+  rm_serial
+  rm_yamr
+)
+
+install(TARGETS pestpp-glm RUNTIME DESTINATION ${BINDIR})

--- a/src/programs/pestpp-ies/CMakeLists.txt
+++ b/src/programs/pestpp-ies/CMakeLists.txt
@@ -1,0 +1,12 @@
+# This CMake file is part of PEST++
+
+add_executable(pestpp-ies pestpp-ies.cpp)
+
+target_compile_options(pestpp-ies PRIVATE ${PESTPP_CXX_WARN_FLAGS})
+
+target_link_libraries(pestpp-ies
+  rm_serial
+  rm_yamr
+)
+
+install(TARGETS pestpp-ies RUNTIME DESTINATION ${BINDIR})

--- a/src/programs/pestpp-opt/CMakeLists.txt
+++ b/src/programs/pestpp-opt/CMakeLists.txt
@@ -1,0 +1,14 @@
+# This CMake file is part of PEST++
+
+add_executable(pestpp-opt pestpp-opt.cpp)
+
+target_compile_options(pestpp-opt PRIVATE ${PESTPP_CXX_WARN_FLAGS})
+
+target_link_libraries(pestpp-opt
+  opt
+  rm_external
+  rm_serial
+  rm_yamr
+)
+
+install(TARGETS pestpp-opt RUNTIME DESTINATION ${BINDIR})

--- a/src/programs/pestpp-pso/CMakeLists.txt
+++ b/src/programs/pestpp-pso/CMakeLists.txt
@@ -1,0 +1,29 @@
+# This CMake file is part of PEST++
+
+add_executable(pestpp-pso
+  bestsubs.f90
+  estimation.f90
+  objsubs.f90
+  pareto.f90
+  paretosubs.f90
+  parsubs.f90
+  parunc.f90
+  pertsubs.f90
+  psomain.f90
+  readsubs.f90
+  rmsubs.f90
+  utilsubs.f90
+  writesubs.f90
+)
+
+target_link_libraries(pestpp-pso
+  rm_wrappers
+  ${LAPACK_LIBRARIES}
+)
+
+if(NOT "${BUILD_SHARED_LIBS}" AND
+    "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")
+  set_property(TARGET pestpp-pso PROPERTY LINKER_LANGUAGE Fortran)
+endif()
+
+install(TARGETS pestpp-pso RUNTIME DESTINATION ${BINDIR})

--- a/src/programs/sweep/CMakeLists.txt
+++ b/src/programs/sweep/CMakeLists.txt
@@ -1,0 +1,12 @@
+# This CMake file is part of PEST++
+
+add_executable(pestpp-swp sweep.cpp)
+
+target_compile_options(pestpp-swp PRIVATE ${PESTPP_CXX_WARN_FLAGS})
+
+target_link_libraries(pestpp-swp
+  rm_serial
+  rm_yamr
+)
+
+install(TARGETS pestpp-swp RUNTIME DESTINATION ${BINDIR})

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -1,0 +1,5 @@
+# This CMake file is part of PEST++
+
+if(Fortran_ENABLED)
+  add_subdirectory(inschekpp)
+endif()

--- a/src/utilities/inschekpp/CMakeLists.txt
+++ b/src/utilities/inschekpp/CMakeLists.txt
@@ -1,0 +1,10 @@
+# This CMake file is part of PEST++
+
+add_executable(inschekpp
+  inschek.F
+  nblnk.F
+  pgetcl.F
+  space.F
+)
+
+install(TARGETS inschekpp RUNTIME DESTINATION ${BINDIR})


### PR DESCRIPTION
This is a basic CMake setup for PEST++, which works on Linux and Windows (I don't have access to a mac). Most of the features used here are standard CMake features, with a few custom things, such as the install locations. CMake files are also there for mio and propack, but these are commented-out, as they are not used anywhere.

If this all looks good, we can consider removing the older Makefiles, which are unrelated. Possibly also the .vcxproj files too, since the CMake setup can generate these files, as needed.

Testing for Linux is done with Travis CI and testing for Windows is done with AppVeyor (it seems this wasn't done previously). I've checked with Intel on Linux, which works. Also Clang++ works too.

Documentation is (quickly) written up in a separate document, and can be reviewed to see if it's helpful/makes sense.

Closes #45