### PR TITLE
CMake: change local install to copy to os-tag rather than symlink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,25 +88,26 @@ endif()
 # https://www.linux.com/training-tutorials/cmake-recipe-2-install-local-folder-build-dir-testing/
 # Use an extra command to copy binaries into a sub-directory within bin -- please remove soon
 if(WIN32)
-  set(_local_install_COMMAND
+  set(_local_install_COMMAND_to_be_removed
     cd "${PESTPP_SOURCE_DIR}\\bin" &&
-    rmdir /q /s ${_ostag} &&
-    mklink /j ${_ostag} .
+    rd /q /s ${_ostag} &&
+    md ${_ostag} &&
+    copy /b pestpp-* ${_ostag}\\
   )
 else()
-  set(_local_install_COMMAND
+  set(_local_install_COMMAND_to_be_removed
     cd "${PESTPP_SOURCE_DIR}/bin" &&
     rm -rf ${_ostag} &&
-    ln -s . ${_ostag}
+    mkdir ${_ostag} &&
+    cp pestpp-* ${_ostag}/
   )
 endif()
 add_custom_target(local_install
   ALL
   "${CMAKE_COMMAND}"
-    -D CMAKE_INSTALL_BINDIR=bin/${_ostag}
     -D CMAKE_INSTALL_PREFIX=${PESTPP_SOURCE_DIR}
     -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_install.cmake"
-  COMMAND ${_local_install_COMMAND}
+  COMMAND ${_local_install_COMMAND_to_be_removed}
   DEPENDS
     pestpp-glm
     pestpp-ies

--- a/benchmarks/basic_tests.py
+++ b/benchmarks/basic_tests.py
@@ -20,24 +20,10 @@ os.environ["PATH"] += os.pathsep + bin_path
 
 
 bin_path = os.path.join("..","..","..","bin")
-
-
-use_intel= os.getenv('USE_INTEL', False)
-# if len(sys.argv) > 1 and sys.argv[1].lower() == 'intel':
-#     use_intel = True
-#     print("using intel windows binaries")
-
-
+exe = ""
 if "windows" in platform.platform().lower():
-    if use_intel:
-        print("using intel windows binaries")
-        exe_path = os.path.join(bin_path, "iwin", "ipestpp-ies.exe")
-    else:
-        exe_path = os.path.join(bin_path, "win", "pestpp-ies.exe")
-elif "darwin" in platform.platform().lower():
-    exe_path = os.path.join(bin_path,  "mac", "pestpp-ies")
-else:
-    exe_path = os.path.join(bin_path, "linux", "pestpp-ies")
+    exe = ".exe"
+exe_path = os.path.join(bin_path, "pestpp-ies" + exe)
 
 
 noptmax = 4


### PR DESCRIPTION
Also update benchmarks/basic_tests.py to just look in bin rather than os-tagged sub-directory. Similar changes can be made to the other test repos to transition.

The main thing done in this PR is to put the same copies of executables from ./bin to ./bin/linux (or whichever os-tag). This is to allow less disruption of workflow while moving away from subdirs in bin, since symbolic links are a bit disruptive.

The hacky command to eventually be removed is renamed to be clear.