### PR TITLE
Add script to build linux via Holy Build Box

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,10 @@ endif()
 
 # Use a custom command to locally install binaries after compiling
 # https://www.linux.com/training-tutorials/cmake-recipe-2-install-local-folder-build-dir-testing/
+option(INSTALL_LOCAL "Install local executables in ./bin" ON)
+if(INSTALL_LOCAL)
+  set(_OPTION_INSTALL_LOCAL_ALL ALL)
+endif()
 # Use an extra command to copy binaries into a sub-directory within bin -- please remove soon
 if(WIN32)
   set(_local_install_COMMAND_to_be_removed
@@ -135,7 +139,7 @@ else()
   )
 endif()
 add_custom_target(local_install
-  ALL
+  ${_OPTION_INSTALL_LOCAL_ALL}
   "${CMAKE_COMMAND}"
     -D CMAKE_INSTALL_PREFIX=${PESTPP_SOURCE_DIR}
     -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_install.cmake"
@@ -146,7 +150,7 @@ add_custom_target(local_install
     pestpp-opt
     pestpp-sen
     pestpp-swp
-  COMMENT "Installing local binaries to ${PESTPP_SOURCE_DIR}/bin"
+  COMMENT "Installing local executables to ${PESTPP_SOURCE_DIR}/bin"
 )
 
 # Packaging

--- a/build_pestpp_mac.sh
+++ b/build_pestpp_mac.sh
@@ -1,7 +1,0 @@
-rm -r build
-mkdir build
-cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icpc ..
-make -j 5 
-cpack
-cp *.tar.gz ../

--- a/documentation/cmake.md
+++ b/documentation/cmake.md
@@ -20,6 +20,7 @@ Variables and options are passed to CMake using `-D<var>=<value>` options to the
 * `CMAKE_CXX_COMPILER` - Normally this is detected, but it can be overridden to use a different C++ compiler.
 * `CMAKE_Fortran_COMPILER` - If specified (such as `ifort`), this enables Fortran support to build additional targets.
 * `ENABLE_Fortran=OFF` - If set `ON`, enable Fortran support, using default Fortran compiler to build additional targets.
+* `INSTALL_LOCAL=ON` - By default, executables are installed locally in ./bin after they are built, which is handy for testing.
 
 ## Linux and macOS
 

--- a/scripts/build_pestpp_linux_hbb.sh
+++ b/scripts/build_pestpp_linux_hbb.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# This script runs within docker, using the command (which may require sudo):
+#   docker run -t -i --rm -v $(dirname `pwd`):/io phusion/holy-build-box-64:latest bash /io/scripts/build_pestpp_linux_hbb.sh
+
+set -e
+
+# Activate Holy Build Box environment
+source /hbb_exe/activate
+
+#unset LIBRARY_PATH
+unset LDFLAGS
+unset CXXFLAGS
+
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/hbb_exe -DINSTALL_LOCAL=OFF /io
+make -j
+cpack -G TGZ
+
+# Copy result to host, changing ownership to same as directory
+FILE=$(ls *.tar.gz)
+cp $FILE /io/
+chown $(stat /io -c %u:%g) /io/$FILE
+
+echo "See result $FILE"

--- a/scripts/build_pestpp_mac.sh
+++ b/scripts/build_pestpp_mac.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+full_path=$(realpath $0)
+script_path=$(dirname $full_path)
+cd "$script_path"/..
+
+rm -r build
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icpc ..
+make -j
+cpack -G TGZ
+cp *.tar.gz ../

--- a/scripts/build_pestpp_win.bat
+++ b/scripts/build_pestpp_win.bat
@@ -1,3 +1,8 @@
+@echo off
+
+set first_path=%cd%
+cd "%~dp0\.."
+
 rmdir /Q /S bin
 rmdir /Q /S build
 mkdir build
@@ -17,4 +22,5 @@ cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
 ninja
 cpack -G ZIP
 copy /y *.zip ..\
-cd ..
+
+cd %first_path%


### PR DESCRIPTION
The most interesting thing done here is to use docker to build a mostly portable linux package using [Holy Build Box](https://github.com/phusion/holy-build-box). To do this, first install docker ([link](https://docs.docker.com/get-docker/)), then use these commands to run the build script:

    cd scripts
    docker run -t -i --rm -v $(dirname `pwd`):/io phusion/holy-build-box-64:latest bash /io/scripts/build_pestpp_linux_hbb.sh

(`sudo` might be required to run `docker`)

Other things done here:
* Add CMake option INSTALL_LOCAL=ON to disable local install - this is required to prevent docker's build to be installed on host. But keep this option's default `ON`, because it seems handy.
* Move other build scripts into 'script' subdirectory - this is to group related scripts off the root directory. Some extra commands are added so they can be called (e.g.) either `./scripts/build_pestpp_mac.sh` or `cd scripts && ./build_pestpp_mac.sh`. Let me know if I've gone too far, and I can revise some of these edits before merging.