### PR TITLE
CMake: add FORCE_STATIC option, use if for mac builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,10 @@ else()
   set(Fortran_ENABLED FALSE)
 endif()
 
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
+message(STATUS "CMAKE_THREAD_LIBS_INIT=${CMAKE_THREAD_LIBS_INIT}")
 
 # Ensure C++11 is used
 set(CMAKE_CXX_STANDARD 11)
@@ -93,8 +96,11 @@ if(WIN32)
   add_compile_definitions(_WIN32_WINNT=0x0600)
 endif()
 
-option(BUILD_SHARED_LIBS "Build PEST++ shared (default is static)" OFF)
+option(BUILD_SHARED_LIBS "Build PEST++ shared (default is static, OFF)" OFF)
 message(STATUS "BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}")
+
+option(FORCE_STATIC "Force '-static' flag to link applications (default OFF)" OFF)
+message(STATUS "FORCE_STATIC=${FORCE_STATIC}")
 
 # Default install directories
 include(GNUInstallDirs)

--- a/documentation/cmake.md
+++ b/documentation/cmake.md
@@ -14,7 +14,8 @@ The normal approach to compile a project with CMake is outside of the source tre
 
 Variables and options are passed to CMake using `-D<var>=<value>` options to the command-line interface.
 
-* `BUILD_SHARED_LIBS=OFF` - Static libraries are built by default, but shared libraries can be enabled by setting value to `ON`.
+* `BUILD_SHARED_LIBS=OFF` - Static libraries are built by default, but shared libraries can be enabled by setting value to `ON`. Note that shared libraries are not actively developed or tested.
+* `FORCE_STATIC=OFF` - Force `-static` flag to link PEST++ applications. This may be required in certain situations to avoid segmentation faults, but is generally not recommended.
 * `CMAKE_BUILD_TYPE` - Specify the build type for single-configuration generators, including Makefile and Ninja. Possible values are `Debug`, `Release`, `RelWithDebInfo`, or `MinSizeRel`.
 * `CMAKE_INSTALL_PREFIX` - If CMake is used to install, specify an install prefix, such as `$HOME/.local`.
 * `CMAKE_CXX_COMPILER` - Normally this is detected, but it can be overridden to use a different C++ compiler.

--- a/scripts/build_pestpp_mac.sh
+++ b/scripts/build_pestpp_mac.sh
@@ -9,7 +9,7 @@ cd "$script_path"/..
 rm -r build
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icpc ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icpc -DFORCE_STATIC=ON ..
 make -j
 cpack -G TGZ
 cp *.tar.gz ../

--- a/src/libs/common/CMakeLists.txt
+++ b/src/libs/common/CMakeLists.txt
@@ -18,6 +18,9 @@ target_link_libraries(common
   Eigen
   Threads::Threads
 )
+if(FORCE_STATIC)
+  target_link_libraries(common -static)
+endif()
 
 target_compile_features(common PUBLIC cxx_std_11)
 set_target_properties(common PROPERTIES CXX_EXTENSIONS OFF)


### PR DESCRIPTION
The `-static` flag should be used at last resort, as it creates bigger binaries, may cause seg faults, and may show warnings like:
```
../../libs/common/libcommon.a(network_wrapper.cpp.o): In function `w_getaddrinfo[abi:cxx11](char const*, char const*, addrinfo const*, addrinfo**)':
network_wrapper.cpp:(.text+0x1be): warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```
however, in other situations it can be used to avoid seg faults. This PR provides the option to use the flag, or not (default).

Other attempts in this PR are to try and get CMake to use the system POSIX Threads library in use with the `-pthread` flag. These flags are [highly recommended](https://cmake.org/cmake/help/latest/module/FindThreads.html).