### PR TITLE
Build Fortran targets when possible; fix Windows Fortran linking

### DIFF
--- a/scripts/build_pestpp_iwin.bat
+++ b/scripts/build_pestpp_iwin.bat
@@ -1,0 +1,17 @@
+@echo off
+
+set first_path=%cd%
+cd "%~dp0\.."
+
+rmdir /Q /S bin
+rmdir /Q /S build
+mkdir build
+call "C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\bin\compilervars.bat" intel64
+cd build
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icl -DCMAKE_Fortran_COMPILER=ifort ..
+ninja
+cpack -G ZIP
+copy /y *.zip ..\
+
+cd %first_path%
+pause

--- a/scripts/build_pestpp_linux_hbb.sh
+++ b/scripts/build_pestpp_linux_hbb.sh
@@ -5,14 +5,18 @@
 set -e
 
 # Activate Holy Build Box environment
-source /hbb_exe/activate
+hbb_prefix=/hbb_exe
+source /$hbb_prefix/activate
+
+# Dependencies
+yum install -y lapack-devel
 
 #unset LIBRARY_PATH
 unset LDFLAGS
 unset CXXFLAGS
 
 mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/hbb_exe -DINSTALL_LOCAL=OFF /io
+cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_Fortran=ON -DCMAKE_INSTALL_PREFIX=$hbb_prefix -DINSTALL_LOCAL=OFF /io
 make -j
 cpack -G TGZ
 

--- a/scripts/build_pestpp_mac.sh
+++ b/scripts/build_pestpp_mac.sh
@@ -11,7 +11,7 @@ cd "$script_path"/..
 rm -r build
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icpc -DFORCE_STATIC=ON ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icpc -DCMAKE_Fortran_COMPILER=ifort ..
 make -j
 cpack -G TGZ
 cp *.tar.gz ../

--- a/scripts/build_pestpp_win.bat
+++ b/scripts/build_pestpp_win.bat
@@ -3,16 +3,6 @@
 set first_path=%cd%
 cd "%~dp0\.."
 
-rmdir /Q /S bin
-rmdir /Q /S build
-mkdir build
-call "C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\bin\compilervars.bat" intel64
-cd build
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icl ..
-ninja
-cpack -G ZIP
-copy /y *.zip ..\
-
 cd ..
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
 rmdir /Q /S build

--- a/src/libs/run_managers/wrappers/CMakeLists.txt
+++ b/src/libs/run_managers/wrappers/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(rm_wrappers STATIC
 )
 
 if(WIN32)
-  target_compile_definitions(rm_wrappers PRIVATE _SCL_SECURE_NO_WARNINGS)
+  target_compile_definitions(rm_wrappers PRIVATE _SCL_SECURE_NO_WARNINGS EXTERNAL_UPPER)
 endif()
 
 target_compile_options(rm_wrappers PRIVATE ${PESTPP_CXX_WARN_FLAGS})

--- a/src/libs/run_managers/wrappers/RunManagerFortranWrapper.h
+++ b/src/libs/run_managers/wrappers/RunManagerFortranWrapper.h
@@ -3,55 +3,23 @@
 #ifndef RUNMANAGER_FORTRAN_WRAP_H_
 #define RUNMANAGER_FORTRAN_WRAP_H_
 
-extern "C"
-{
-int RMIF_CREATE_SERIAL(char *f_comline, int  *comline_str_len, int *comline_array_len,
-	char *f_tpl, int  *tpl_str_len, int *tpl_array_len,
-	char *f_inp, int  *inp_str_len, int *inp_array_len,
-	char *f_ins, int  *ins_str_len, int *ins_array_len,
-	char *f_out, int  *out_str_len, int *out_array_len,
-	char *f_storfile, int *storfile_len,
-	char *f_rundir, int *rundir_len, int *n_max_fail);
+#ifdef EXTERNAL_UPPER
+/* E.g. Windows Intel uses different name conventions */
+#define rmif_create_serial_ RMIF_CREATE_SERIAL
+#define rmif_create_panther_ RMIF_CREATE_PANTHER
+#define rmif_add_run_ RMIF_ADD_RUN
+#define rmif_add_run_with_info_ RMIF_ADD_RUN_WITH_INFO
+#define rmif_initialize_ RMIF_INITIALIZE
+#define rmif_initialize_restart_ RMIF_INITIALIZE_RESTART
+#define rmif_reinitialize_ RMIF_REINITIALIZE
+#define rmif_run_ RMIF_RUN
+#define rmif_run_until_ RMIF_RUN_UNTIL
+#define rmif_get_run_ RMIF_GET_RUN
+#define rmif_get_run_with_info_ RMIF_GET_RUN_WITH_INFO
+#define rmif_delete_ RMIF_DELETE
+#define rmif_get_failed_run_ids_ RMIF_GET_FAILED_RUN_IDS
+#define rmif_get_num_total_runs_ RMIF_GET_NUM_TOTAL_RUNS
 
-int RMIF_CREATE_PANTHER(char *f_comline, int  *comline_str_len, int *comline_array_len,
-	char *f_tpl, int  *tpl_str_len, int *tpl_array_len,
-	char *f_inp, int  *inp_str_len, int *inp_array_len,
-	char *f_ins, int  *ins_str_len, int *ins_array_len,
-	char *f_out, int  *out_str_len, int *out_array_len,
-	char *f_storfile, int *storfile_len,
-	char *f_port, int *f_port_len,
-	char *f_info_filename, int *info_filename_len, int *n_max_fail);
+#endif //EXTERNAL_UPPER
 
-int RMIF_ADD_RUN(double *parameter_data, int *npar, int *id);
-
-int RMIF_ADD_RUN_WITH_INFO(double *parameter_data, int *npar, int *id,
-	char *f_info_txt, int  *info_txt_len, double *info_value);
-
-int RMIF_INITIALIZE(char *f_pname, int  *pname_str_len, int *pname_array_len,
-				 char *f_oname, int  *oname_str_len, int *oname_array_len);
-
-int RMIF_INITIALIZE_RESTART(char *f_storfile, int *storfile_len);
-
-int RMIF_REINITIALIZE();
-
-int RMIF_RUN();
-
-int RMIF_RUN_UNTIL(int *condition, int *no_ops, double *time_sec, int *return_cond);
-
-int RMIF_GET_RUN(int *run_id, double *parameter_data, int *npar, double *obs_data, int *nobs);
-
-int RMIF_GET_RUN_WITH_INFO(int *run_id, double *parameter_data, int *npar, double *obs_data, int *nobs,
-	char *f_info_txt, int  *info_txt_len, double *info_value);
-
-
-int RMIF_GET_NUM_FAILED_RUNS(int *nfail);
-
-int RMIF_GET_FAILED_RUN_IDS(int *run_id_array, int *len_run_id_array);
-
-int RMIF_GET_NUM_TOTAL_RUNS(int *nruns);
-
-int RMFI_DELETE();
-
-
-}
 #endif //RUNMANAGER_FORTRAN_WRAP_H_


### PR DESCRIPTION
This does the following:
* Adjust build scripts to build Fortran objects (`pestpp-pso` and `inschekpp`), only if Fortran is available
* `build_pestpp_win.bat` is split into `build_pestpp_iwin.bat` (to build Fortran stuff)
* Change use of `RunManagerFortranWrapper.h` to use a `EXTERNAL_UPPER` define. The older content didn't really make sense, so it's been replaced. This is a quick fix, but not really robust. Ideally, Fortran 2003 [BIND(C)](https://software.intel.com/content/www/us/en/develop/documentation/fortran-compiler-developer-guide-and-reference/top/compiler-reference/mixed-language-programming/standard-tools-for-interoperability/bind.html) should be used.

One thing that isn't done (but can be amended) is to build Fortran objects with Travis CI. Is this desired? If so, are there tests?