### PR TITLE
Hotfix mi except handler

### DIFF
--- a/src/libs/common/config_os.h
+++ b/src/libs/common/config_os.h
@@ -2,7 +2,7 @@
 #define CONFIG_OS_H_
 
 
-#define PESTPP_VERSION "5.0.0";
+#define PESTPP_VERSION "5.0.1";
 
 #if defined(_WIN32) || defined(_WIN64)
 #define OS_WIN

--- a/src/libs/common/utilities.cpp
+++ b/src/libs/common/utilities.cpp
@@ -624,7 +624,7 @@ void  thread_exceptions::rethrow()
 		}
 		catch (const std::exception& e)
 		{
-			ss << e.what() << ", ";
+			ss << e.what() << " ";
 		}
 	}
 	throw runtime_error(ss.str());

--- a/src/libs/pestpp_common/EnsembleSmoother.cpp
+++ b/src/libs/pestpp_common/EnsembleSmoother.cpp
@@ -2480,7 +2480,7 @@ ParameterEnsemble IterEnsembleSmoother::calc_localized_upgrade_threaded(double c
 				catch (...)
 				{
 					//ss.str("");
-					ss << " thread " << i << "raised an exception: " << e.what();
+					ss << " thread " << i << "raised an exception: ";
 					//throw runtime_error(ss.str());
 				}
 			}

--- a/src/libs/pestpp_common/EnsembleSmoother.cpp
+++ b/src/libs/pestpp_common/EnsembleSmoother.cpp
@@ -2436,35 +2436,58 @@ ParameterEnsemble IterEnsembleSmoother::calc_localized_upgrade_threaded(double c
 		message(2, "waiting to join threads");
 		//for (auto &t : threads)
 		//	t.join();
+		ss.str("");
+		int num_exp = 0;
+
 		for (int i = 0; i < num_threads; ++i)
 		{
+			bool found = false;
 			if (exception_ptrs[i])
 			{
+				found = true;
+				num_exp++;
 				try
 				{
 					rethrow_exception(exception_ptrs[i]);
 				}
 				catch (const std::exception& e)
 				{
-					ss.str("");
-					ss << "thread " << i << "raised an exception: " << e.what();
-					throw runtime_error(ss.str());
+					//ss.str("");
+					ss << " thread " << i << "raised an exception: " << e.what();
+					//throw runtime_error(ss.str());
+				}
+				catch (...)
+				{
+					//ss.str("");
+					ss << " thread " << i << "raised an exception";
+					//throw runtime_error(ss.str());
 				}
 			}
 			threads[i].join();
-			if (exception_ptrs[i])
+			if ((exception_ptrs[i]) && (!found))
 			{
+				num_exp++;
 				try
 				{
 					rethrow_exception(exception_ptrs[i]);
 				}
 				catch (const std::exception& e)
 				{
-					ss.str("");
-					ss << "thread " << i << "raised an exception: " << e.what();
-					throw runtime_error(ss.str());
+					//ss.str("");
+					ss << " thread " << i << "raised an exception: " << e.what();
+					//throw runtime_error(ss.str());
+				}
+				catch (...)
+				{
+					//ss.str("");
+					ss << " thread " << i << "raised an exception: " << e.what();
+					//throw runtime_error(ss.str());
 				}
 			}
+		}
+		if (num_exp > 0)
+		{
+			throw runtime_error(ss.str());
 		}
 		message(2, "threaded localized upgrade calculation done");
 	}

--- a/src/libs/run_managers/abstract_base/model_interface.cpp
+++ b/src/libs/run_managers/abstract_base/model_interface.cpp
@@ -398,7 +398,7 @@ void ModelInterface::write_input_files(Parameters *pars_ptr)
 	//	pars_ptr->update_without_clear(pro_pars.get_keys(), pro_pars.get_data_vec(pro_pars.get_keys()));
 	if (num_exp > 0)
 	{
-		cout << "errors processing template files: " << endl << ss.str();
+		//cout << "errors processing template files: " << endl << ss.str();
 		throw runtime_error(ss.str());
 	}
 
@@ -509,7 +509,7 @@ void ModelInterface::read_output_files(Observations *obs)
 
 	if (num_exp > 0)
 	{
-		cout << "errors processing instruction files: " << endl << ss.str();
+		//cout << "errors processing instruction files: " << endl << ss.str();
 		throw runtime_error(ss.str());
 	}
 

--- a/src/libs/run_managers/abstract_base/model_interface.cpp
+++ b/src/libs/run_managers/abstract_base/model_interface.cpp
@@ -257,6 +257,10 @@ void process_template_file_thread(int tid, vector<int>& tpl_idx, ThreadedTemplat
 	{
 		ttp.work(tid, tpl_idx, pars, pro_pars);
 	}
+	catch (const std::exception& e)
+	{
+		eptr = current_exception();
+	}
 	catch (...)
 	{
 		eptr = current_exception();
@@ -271,6 +275,10 @@ void process_instruction_file_thread(int tid, vector<int>& ins_idx, ThreadedInst
 	try
 	{
 		tip.work(tid, ins_idx, obs, additional_ins_delims);
+	}
+	catch (const std::exception& e)
+	{
+		eptr = current_exception();
 	}
 	catch (...)
 	{
@@ -306,24 +314,37 @@ void ModelInterface::write_input_files(Parameters *pars_ptr)
 	{
 		threads.push_back(thread(process_template_file_thread, i, std::ref(tpl_idx), std::ref(ttp), *pars_ptr, std::ref(pro_pars), std::ref(exception_ptrs[i])));
 	}
-
+	stringstream ss;
+	int num_exp = 0;
 	for (int i = 0; i < num_threads; ++i)
 	{
+		bool found = false;
 		if (exception_ptrs[i])
 		{
+			found = true;
 			try
 			{
 				rethrow_exception(exception_ptrs[i]);
 			}
 			catch (const std::exception& e)
 			{
-				stringstream ss;
-				ss << "thread processing template file '" << tplfile_vec[i] << "' raised an exception: " << e.what();
-				throw runtime_error(ss.str());
+				//stringstream ss;
+				ss << " thread processing template file '" << tplfile_vec[i] << "' raised an exception: " << e.what() << endl;
+				num_exp++;
+				//cout << "Error: " << ss.str();
+				//throw runtime_error(ss.str());
+			}
+			catch (...)
+			{
+				//stringstream ss;
+				ss << " thread processing template file '" << tplfile_vec[i] << "' raised an exception" << endl;
+				num_exp++;
+				//cout << "Error: " << ss.str();
+				//throw runtime_error(ss.str());
 			}
 		}
 		threads[i].join();
-		if (exception_ptrs[i])
+		if ((exception_ptrs[i]) && (!found))
 		{
 			try
 			{
@@ -331,9 +352,19 @@ void ModelInterface::write_input_files(Parameters *pars_ptr)
 			}
 			catch (const std::exception& e)
 			{
-				stringstream ss;
-				ss << "thread processing template file '" << tplfile_vec[i] << "' raised an exception: " << e.what();
-				throw runtime_error(ss.str());
+				//stringstream ss;
+				ss << " thread processing template file '" << tplfile_vec[i] << "' raised an exception: " << e.what() << endl;
+				num_exp++;
+				//cout << "Error: " << ss.str();
+				//throw runtime_error(ss.str());
+			}
+			catch (...)
+			{
+				//stringstream ss;
+				ss << " thread processing template file '" << tplfile_vec[i] << "' raised an exception" << endl;
+				num_exp++;
+				//cout << "Error: " << ss.str();
+				//throw runtime_error(ss.str());
 			}
 		}
 	}
@@ -365,6 +396,12 @@ void ModelInterface::write_input_files(Parameters *pars_ptr)
 	//update pars to account for possibly truncated par values...important for jco calcs
 	//for (auto pro_pars : pro_par_vec)
 	//	pars_ptr->update_without_clear(pro_pars.get_keys(), pro_pars.get_data_vec(pro_pars.get_keys()));
+	if (num_exp > 0)
+	{
+		cout << "errors processing template files: " << endl << ss.str();
+		throw runtime_error(ss.str());
+	}
+
 	pars_ptr->update_without_clear(pro_pars.get_keys(), pro_pars.get_data_vec(pro_pars.get_keys()));
 	cout << pest_utils::get_time_string() << " done, took " << pest_utils::get_duration_sec(start_time) << " seconds" << endl;
 }
@@ -396,24 +433,37 @@ void ModelInterface::read_output_files(Observations *obs)
 		threads.push_back(thread(process_instruction_file_thread, i, std::ref(ins_idx), std::ref(tip), std::ref(temp_obs), additional_ins_delimiters,
 			std::ref(exception_ptrs[i])));
 	}
-
+	stringstream ss;
+	int num_exp = 0;
 	for (int i = 0; i < num_threads; ++i)
 	{
+		bool found = false;
 		if (exception_ptrs[i])
 		{
+			found = true;
 			try
 			{
 				rethrow_exception(exception_ptrs[i]);
 			}
 			catch (const std::exception& e)
 			{
-				stringstream ss;
-				ss << "thread processing instruction file '" << insfile_vec[i] << "' raised an exception: " << e.what();
-				throw runtime_error(ss.str());
+				//stringstream ss;
+				ss << " thread processing instruction file '" << insfile_vec[i] << "' raised an exception: " << e.what() << endl;
+				//cout << "Error: " << ss.str() << endl;
+				//throw runtime_error(ss.str());
+				num_exp++;
+			}
+			catch (...)
+			{
+				//stringstream ss;
+				ss << " thread processing instruction file '" << insfile_vec[i] << "' raised an exception" << endl;
+				//cout << "Error: " << ss.str() << endl;
+				//throw runtime_error(ss.str());
+				num_exp++;
 			}
 		}
 		threads[i].join();
-		if (exception_ptrs[i])
+		if ((exception_ptrs[i]) && (!found))
 		{
 			try
 			{
@@ -421,9 +471,19 @@ void ModelInterface::read_output_files(Observations *obs)
 			}
 			catch (const std::exception& e)
 			{
-				stringstream ss;
-				ss << "thread processing instruction file '" << insfile_vec[i] << "' raised an exception: " << e.what();
-				throw runtime_error(ss.str());
+				//stringstream ss;
+				ss << " thread processing instruction file '" << insfile_vec[i] << "' raised an exception: " << e.what() << endl;
+				//cout << "Error: " << ss.str() << endl;
+				//throw runtime_error(ss.str());
+				num_exp++;
+			}
+			catch (...)
+			{
+				//stringstream ss;
+				ss << " thread processing instruction file '" << insfile_vec[i] << "' raised an exception" << endl;
+				//cout << "Error: " << ss.str() << endl;
+				//throw runtime_error(ss.str());
+				num_exp++;
 			}
 		}
 	}
@@ -446,6 +506,13 @@ void ModelInterface::read_output_files(Observations *obs)
 		pro_obs = instructionfiles[i].read_output_file(outfile_vec[i]);
 		temp_obs.update_without_clear(pro_obs.get_keys(), pro_obs.get_data_vec(pro_obs.get_keys()));
 	}*/
+
+	if (num_exp > 0)
+	{
+		cout << "errors processing instruction files: " << endl << ss.str();
+		throw runtime_error(ss.str());
+	}
+
 	unordered_set<string> ins_names, pst_names;
 	vector<string> t, diff;
 	t = obs->get_keys();
@@ -667,8 +734,14 @@ void ModelInterface::run(pest_utils::thread_flag* terminate, pest_utils::thread_
 		finished->set(true);
 
 	}
+	catch (const std::exception& e)
+	{
+		cout << "exception raised by run thread: " << e.what() << endl;
+		shared_execptions->add(current_exception());
+	}
 	catch (...)
 	{
+		cout << "exception raised by run thread" << endl;
 		shared_execptions->add(current_exception());
 	}
 	return;

--- a/src/libs/run_managers/serial/RunManagerSerial.cpp
+++ b/src/libs/run_managers/serial/RunManagerSerial.cpp
@@ -92,8 +92,7 @@ void RunManagerSerial::run()
 			{
 				update_run_failed(i_run);
 				failed_runs++;
-				cerr << endl;
-				cerr << "  " << ex.what() << endl;
+				cerr << "  Error running model: " << ex.what() << endl;
 				cerr << "  Aborting model run" << endl << endl;
 
 			}
@@ -101,7 +100,6 @@ void RunManagerSerial::run()
 			{
 				update_run_failed(i_run);
 				failed_runs++;
-				cerr << endl;
 				cerr << "  Error running model" << endl;
 				cerr << "  Aborting model run" << endl << endl;
 			}


### PR DESCRIPTION
improved thread-level exception handling.  Now if tpl/ins and localizer solve threads raise an exception, the remaining threads are joined, then the exception is rethrown.  This should prevent core dumps on linux