### PR TITLE
Develop

### DIFF
--- a/src/libs/common/config_os.h
+++ b/src/libs/common/config_os.h
@@ -2,7 +2,7 @@
 #define CONFIG_OS_H_
 
 
-#define PESTPP_VERSION "5.1.14";
+#define PESTPP_VERSION "5.1.15";
 
 #if defined(_WIN32) || defined(_WIN64)
 #define OS_WIN

--- a/src/libs/pestpp_common/EnsembleMethodUtils.cpp
+++ b/src/libs/pestpp_common/EnsembleMethodUtils.cpp
@@ -4306,7 +4306,7 @@ void EnsembleMethod::initialize(int cycle, bool run, bool use_existing)
 		{
 		    if ((cycle != NetPackage::NULL_DA_CYCLE) && (num_ineq == nnz_obs))
             {
-		        message(0,"initial actual phi mean too low but only ineqaulity are being used, continuing...");
+		        message(0,"initial actual phi mean too low but only inequality obs are being used, continuing...");
                 continue_anyway = true;
             }
 		    else
@@ -4316,7 +4316,7 @@ void EnsembleMethod::initialize(int cycle, bool run, bool use_existing)
 		{
             if ((cycle != NetPackage::NULL_DA_CYCLE) && (num_ineq == nnz_obs))
             {
-                message(0,"initial actual phi stdev is very low but only ineqaulity are being used, continuing...");
+                message(0,"initial actual phi stdev is very low but only inequality obs are being used, continuing...");
                 continue_anyway = true;
             }
 			else
@@ -4326,7 +4326,7 @@ void EnsembleMethod::initialize(int cycle, bool run, bool use_existing)
 		{
             if ((cycle != NetPackage::NULL_DA_CYCLE) && (num_ineq == nnz_obs))
             {
-                message(0,"initial composite phi mean too low but only ineqaulity are being used, continuing...");
+                message(0,"initial composite phi mean too low but only inequality obs are being used, continuing...");
                 continue_anyway = true;
             }
 			else
@@ -4336,7 +4336,7 @@ void EnsembleMethod::initialize(int cycle, bool run, bool use_existing)
 		{
             if ((cycle != NetPackage::NULL_DA_CYCLE) && (num_ineq == nnz_obs))
             {
-                message(0,"initial composite phi stdev is ver low but only ineqaulity are being used, continuing...");
+                message(0,"initial composite phi stdev is ver low but only inequality obs are being used, continuing...");
                 continue_anyway = true;
             }
 			else

--- a/src/libs/pestpp_common/EnsembleMethodUtils.cpp
+++ b/src/libs/pestpp_common/EnsembleMethodUtils.cpp
@@ -4231,6 +4231,7 @@ void EnsembleMethod::initialize(int cycle, bool run, bool use_existing)
                 {
                     message(0,"all non-zero weighted observations in conflict state, continuing to next cycle");
                     zero_weight_obs(in_conflict,false,false);
+                    ph.update(oe,pe);
                     return;
                 }
             }
@@ -6483,7 +6484,7 @@ void EnsembleMethod::zero_weight_obs(vector<string>& obs_to_zero_weight, bool up
 	message(1, ss.str());
 }
 
-vector<string> EnsembleMethod::detect_prior_data_conflict()
+vector<string> EnsembleMethod::detect_prior_data_conflict(bool save)
 {
 	message(1, "checking for prior-data conflict...");
 	//for now, just really simple metric - checking for overlap
@@ -6520,7 +6521,8 @@ vector<string> EnsembleMethod::detect_prior_data_conflict()
 	int oe_nr = oe.shape().first;
 	int oe_base_nr = oe_base.shape().first;
 	Eigen::VectorXd t;
-	pdccsv << "name,obs_mean,obs_std,obs_min,obs_max,obs_stat_min,obs_stat_max,sim_mean,sim_std,sim_min,sim_max,sim_stat_min,sim_stat_max,distance" << endl;
+
+    pdccsv << "name,obs_mean,obs_std,obs_min,obs_max,obs_stat_min,obs_stat_max,sim_mean,sim_std,sim_min,sim_max,sim_stat_min,sim_stat_max,distance" << endl;
 	for (auto oname : pest_scenario.get_ctl_ordered_nz_obs_names())
 	{
 		//if (ineq.find(oname) != end)
@@ -6580,8 +6582,12 @@ vector<string> EnsembleMethod::detect_prior_data_conflict()
         {
             in_conflict.push_back(oname);
             dist = max((smin - omax), (omin - smax));
-            pdccsv << oname << "," << omn << "," << ostd << "," << omin << "," << omax << "," << omin_stat << "," << omax_stat;
-            pdccsv << "," << smn << "," << sstd << "," << smin << "," << smax << "," << smin_stat << "," << smax_stat << "," << dist << endl;
+
+            pdccsv << oname << "," << omn << "," << ostd << "," << omin << "," << omax << "," << omin_stat << ","
+                   << omax_stat;
+            pdccsv << "," << smn << "," << sstd << "," << smin << "," << smax << "," << smin_stat << ","
+                   << smax_stat << "," << dist << endl;
+
         }
 	}
 

--- a/src/libs/pestpp_common/EnsembleMethodUtils.h
+++ b/src/libs/pestpp_common/EnsembleMethodUtils.h
@@ -326,6 +326,8 @@ public:
 	vector<string>& get_par_dyn_state_names() { return par_dyn_state_names; }
 
 
+
+
 protected:
 	string alg_tag;
 	int  verbose_level;
@@ -405,10 +407,12 @@ protected:
 
 	vector<int> get_subset_idxs(int size, int _subset_size);
 
-	vector<string> detect_prior_data_conflict();
+
 
 	//void set_subset_idx(int size);
 	Eigen::MatrixXd get_Am(const vector<string>& real_names, const vector<string>& par_names);
+
+    vector<string> detect_prior_data_conflict(bool save=true);
 
 	void zero_weight_obs(vector<string>& obs_to_zero_weight, bool update_obscov = true, bool update_oe_base = true);
 

--- a/src/programs/pestpp-da/pestpp-da.cpp
+++ b/src/programs/pestpp-da/pestpp-da.cpp
@@ -857,7 +857,7 @@ int main(int argc, char* argv[])
 			if (childPest.get_ctl_ordered_nz_obs_names().size() > 0)
 			{
 
-				if (pest_scenario.get_control_info().noptmax > 0) // 
+				if ((pest_scenario.get_control_info().noptmax > 0) && (da.get_phi_handler().get_mean(L2PhiHandler::phiType::ACTUAL) > 0)) //
 				{
 
 					da.da_update(*icycle);

--- a/src/programs/pestpp-da/pestpp-da.cpp
+++ b/src/programs/pestpp-da/pestpp-da.cpp
@@ -857,13 +857,24 @@ int main(int argc, char* argv[])
 			if (childPest.get_ctl_ordered_nz_obs_names().size() > 0)
 			{
 
-				if ((pest_scenario.get_control_info().noptmax > 0) && (da.get_phi_handler().get_mean(L2PhiHandler::phiType::ACTUAL) > 0)) //
+				if (pest_scenario.get_control_info().noptmax > 0)
 				{
+                    if ((da.get_phi_handler().get_mean(L2PhiHandler::phiType::ACTUAL) == 0) ||
+                    (da.get_phi_handler().get_mean(L2PhiHandler::phiType::MEAS) == 0))
+                    {
+                        ss.str("");
+                        ss << "...Note:current mean actual and/or measurement phi is too low for solution, continuing..." << endl;
+                        fout_rec << ss.str();
+                        cout << ss.str();
+                    }
+                    else {
 
-					da.da_update(*icycle);
-					ss.str("");
-					ss << file_manager.get_base_filename() << ".global." << *icycle << "." << da.get_iter() << ".pcs.csv";
-					pcs.summarize(*da.get_pe_ptr(), ss.str());
+                        da.da_update(*icycle);
+                        ss.str("");
+                        ss << file_manager.get_base_filename() << ".global." << *icycle << "." << da.get_iter()
+                           << ".pcs.csv";
+                        pcs.summarize(*da.get_pe_ptr(), ss.str());
+                    }
 				}
 				write_global_phi_info(*icycle, f_phi, da, init_real_names);
 			}


### PR DESCRIPTION
added support for ineq obs in pdc calculations, revised `EnsembleMethod.initialize()` to tolerate zero phi if all obs are ineq and da cycle is not null