### PR TITLE
Fix to pars at bounds calcs.

### DIFF
--- a/src/libs/pestpp_common/EnsembleMethodUtils.cpp
+++ b/src/libs/pestpp_common/EnsembleMethodUtils.cpp
@@ -4508,9 +4508,9 @@ void ParChangeSummarizer:: update(ParameterEnsemble& pe)
 			for (int i = 0; i < num_reals; i++)
 			{
 				v = arr[i];
-				if (v > (ub[par_name] * 1.01))
+				if (v > (ub[par_name] - (abs(ub[par_name]) * 0.01)))
 					num_out_u++;
-				else if (v < (lb[par_name] * 0.99))
+				else if (v < (lb[par_name] + (abs(lb[par_name]) * 0.01)))
 				    num_out_l++;
 			}
 			value1 = init_moments.first[par_name];


### PR DESCRIPTION
Assuming pars are in untransformed form lower bound threshold should be: 
lb + abs(lb) * 0.01, and ubound threshold:
ub - abs(ub) * 0.01
I think.