### PR TITLE
GLM: Expand lambda_vec when best lambda is the lowest or highest in the vector; allow lambda_scale_vec values higher than 1

### DIFF
--- a/src/libs/pestpp_common/SVDSolver.cpp
+++ b/src/libs/pestpp_common/SVDSolver.cpp
@@ -1075,7 +1075,7 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 		num_lamb_runs++; 
 		run_manager.update_run(run_id, base_model_pars, base_run.get_obs());
 		//Marquardt Lambda Update Vector
-		vector<double> lambda_vec = base_lambda_vec;
+		vector<double> lambda_vec = pest_scenario.get_pestpp_options().get_base_lambda_vec();
 		
 		std::sort(lambda_vec.begin(), lambda_vec.end());
 		auto iter = std::unique(lambda_vec.begin(), lambda_vec.end());

--- a/src/libs/pestpp_common/SVDSolver.cpp
+++ b/src/libs/pestpp_common/SVDSolver.cpp
@@ -1137,6 +1137,8 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 			Parameters del_numeric_pars = new_numeric_pars - base_numeric_pars;
 			for (double i_scale : lambda_scale_vec)
 			{
+				if (i_scale == 1.0) // skip scale == 1 as we run the normal length anyway
+					continue;
 				Parameters scaled_pars = base_numeric_pars + del_numeric_pars * i_scale;
 				
 				Parameters scaled_ctl_pars = par_transform.numeric2ctl_cp(scaled_pars);
@@ -1283,7 +1285,7 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 
 			auto last_lambda = lambda_vec.back();
 			auto first_lambda = lambda_vec.front();
-
+			file_manager.rec_ofstream() << "Checking to see if best lambda is at the edge" << std::endl;
 			double lambda_spacing_factor = 10.0; // doing powers of 10 for now
 			bool extended = false;
 

--- a/src/libs/pestpp_common/SVDSolver.cpp
+++ b/src/libs/pestpp_common/SVDSolver.cpp
@@ -1274,44 +1274,6 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 				best_upgrade_run = upgrade_run;
 				best_lambda = i_lambda;
 			}
-
-			// Check if best_lambda is at the edge of lambda_vec
-
-			// regrab lambda_vec
-			vector<double> lambda_vec = base_lambda_vec;	
-			std::sort(lambda_vec.begin(), lambda_vec.end());
-			auto iter = std::unique(lambda_vec.begin(), lambda_vec.end());
-			lambda_vec.resize(std::distance(lambda_vec.begin(), iter));
-
-			auto last_lambda = lambda_vec.back();
-			auto first_lambda = lambda_vec.front();
-			file_manager.rec_ofstream() << "Checking to see if best lambda is at the edge" << std::endl;
-			double lambda_spacing_factor = 10.0; // doing powers of 10 for now
-			bool extended = false;
-
-			if (best_lambda == last_lambda)
-			{
-				// Add a new larger lambda
-				double new_lambda = last_lambda * lambda_spacing_factor;
-				if (std::find(lambda_vec.begin(), lambda_vec.end(), new_lambda) == lambda_vec.end())
-				{
-					lambda_vec.push_back(new_lambda);
-					extended = true;
-					file_manager.rec_ofstream() << "*** Extending lambda_vec: added larger lambda " << new_lambda << std::endl;
-				}
-			}
-			else if (best_lambda == first_lambda)
-			{
-				// Add a new smaller lambda
-				double new_lambda = first_lambda / lambda_spacing_factor;
-				if (std::find(lambda_vec.begin(), lambda_vec.end(), new_lambda) == lambda_vec.end())
-				{
-					lambda_vec.push_back(new_lambda);
-					extended = true;
-					file_manager.rec_ofstream() << "*** Extending lambda_vec: added smaller lambda " << new_lambda << std::endl;
-				}
-			}
-			pest_scenario.get_pestpp_options_ptr()->set_base_lambda_vec(lambda_vec);
 		}
 		else
 		{
@@ -1380,6 +1342,44 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 		throw runtime_error("all upgrade runs failed.");
 	}
 
+	// Check if best_lambda is at the edge of lambda_vec
+
+	// regrab lambda_vec
+	vector<double> lambda_vec = base_lambda_vec;	
+	std::sort(lambda_vec.begin(), lambda_vec.end());
+	auto iter = std::unique(lambda_vec.begin(), lambda_vec.end());
+	lambda_vec.resize(std::distance(lambda_vec.begin(), iter));
+
+	auto last_lambda = lambda_vec.back();
+	auto first_lambda = lambda_vec.front();
+	file_manager.rec_ofstream() << "Checking to see if best lambda is at the edge" << std::endl;
+	double lambda_spacing_factor = 10.0; // doing powers of 10 for now
+	bool extended = false;
+
+	if (best_lambda == last_lambda)
+	{
+		// Add a new larger lambda
+		double new_lambda = last_lambda * lambda_spacing_factor;
+		if (std::find(lambda_vec.begin(), lambda_vec.end(), new_lambda) == lambda_vec.end())
+		{
+			lambda_vec.push_back(new_lambda);
+			extended = true;
+			file_manager.rec_ofstream() << "*** Extending lambda_vec: added larger lambda " << new_lambda << std::endl;
+		}
+	}
+	else if (best_lambda == first_lambda)
+	{
+		// Add a new smaller lambda
+		double new_lambda = first_lambda / lambda_spacing_factor;
+		if (std::find(lambda_vec.begin(), lambda_vec.end(), new_lambda) == lambda_vec.end())
+		{
+			lambda_vec.push_back(new_lambda);
+			extended = true;
+			file_manager.rec_ofstream() << "*** Extending lambda_vec: added smaller lambda " << new_lambda << std::endl;
+		}
+	}
+	pest_scenario.get_pestpp_options_ptr()->set_base_lambda_vec(lambda_vec);
+	
 	return best_upgrade_run;
 }
 

--- a/src/libs/pestpp_common/SVDSolver.cpp
+++ b/src/libs/pestpp_common/SVDSolver.cpp
@@ -1169,7 +1169,44 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 		}
 		file_manager.close_file("fpr");
 		RestartController::write_upgrade_runs_built(fout_restart);
+
+		// After finding best_lambda at end of iteration_upgrd()
+		// Insert this logic just before returning best_upgrade_run
+
+		// Check if best_lambda is at the edge of lambda_vec
+		auto last_lambda = lambda_vec.back();
+		auto first_lambda = lambda_vec.front();
+
+		double lambda_spacing_factor = 10.0; // doing powers of 10 for now
+		bool extended = false;
+
+		if (best_lambda == last_lambda)
+		{
+			// Add a new larger lambda
+			double new_lambda = last_lambda * lambda_spacing_factor;
+			if (std::find(lambda_vec.begin(), lambda_vec.end(), new_lambda) == lambda_vec.end())
+			{
+				lambda_vec.push_back(new_lambda);
+				extended = true;
+				file_manager.rec_ofstream() << "*** Extending lambda_vec: added larger lambda " << new_lambda << std::endl;
+			}
+		}
+		else if (best_lambda == first_lambda)
+		{
+			// Add a new smaller lambda
+			double new_lambda = first_lambda / lambda_spacing_factor;
+			if (std::find(lambda_vec.begin(), lambda_vec.end(), new_lambda) == lambda_vec.end())
+			{
+				lambda_vec.push_back(new_lambda);
+				extended = true;
+				file_manager.rec_ofstream() << "*** Extending lambda_vec: added smaller lambda " << new_lambda << std::endl;
+			}
+		}
+		pest_scenario.get_pestpp_options_ptr()->set_base_lambda_vec(lambda_vec);
 	}
+
+	
+	
 	//instance of a Mat for the jco
     Mat j;
     LinearAnalysis la(j, pest_scenario, file_manager, *performance_log, parcov, rand_gen_ptr);

--- a/src/libs/pestpp_common/SVDSolver.cpp
+++ b/src/libs/pestpp_common/SVDSolver.cpp
@@ -1081,11 +1081,6 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 		auto iter = std::unique(lambda_vec.begin(), lambda_vec.end());
 		lambda_vec.resize(std::distance(lambda_vec.begin(), iter));
 
-		file_manager.rec_ofstream() << "DEBUG: lambda list at start of new iteration = ";
-		for (auto val : pest_scenario.get_pestpp_options().get_base_lambda_vec())
-			file_manager.rec_ofstream() << val << " ";
-		file_manager.rec_ofstream() << std::endl;
-
 		int i_update_vec = 0;
 		stringstream message;
 		stringstream prf_message;
@@ -1387,10 +1382,6 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 	std::sort(lambda_vec.begin(), lambda_vec.end());
 	pest_scenario.get_pestpp_options_ptr()->set_base_lambda_vec(lambda_vec);
 
-	file_manager.rec_ofstream() << "DEBUG: lambda list after extend = ";
-	for (auto val : pest_scenario.get_pestpp_options().get_base_lambda_vec())
-		file_manager.rec_ofstream() << val << " ";
-	file_manager.rec_ofstream() << std::endl;
 	return best_upgrade_run;
 }
 

--- a/src/libs/pestpp_common/SVDSolver.cpp
+++ b/src/libs/pestpp_common/SVDSolver.cpp
@@ -1351,7 +1351,7 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 	// Check if best_lambda is at the edge of lambda_vec
 
 	// regrab lambda_vec
-	vector<double> lambda_vec = base_lambda_vec;	
+	vector<double> lambda_vec = pest_scenario.get_pestpp_options().get_base_lambda_vec();	
 	std::sort(lambda_vec.begin(), lambda_vec.end());
 	auto iter = std::unique(lambda_vec.begin(), lambda_vec.end());
 	lambda_vec.resize(std::distance(lambda_vec.begin(), iter));
@@ -1384,6 +1384,7 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 			file_manager.rec_ofstream() << "*** Extending lambda_vec: added smaller lambda " << new_lambda << std::endl;
 		}
 	}
+	std::sort(lambda_vec.begin(), lambda_vec.end());
 	pest_scenario.get_pestpp_options_ptr()->set_base_lambda_vec(lambda_vec);
 
 	file_manager.rec_ofstream() << "DEBUG: lambda list after extend = ";

--- a/src/libs/pestpp_common/SVDSolver.cpp
+++ b/src/libs/pestpp_common/SVDSolver.cpp
@@ -1080,6 +1080,12 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 		std::sort(lambda_vec.begin(), lambda_vec.end());
 		auto iter = std::unique(lambda_vec.begin(), lambda_vec.end());
 		lambda_vec.resize(std::distance(lambda_vec.begin(), iter));
+
+		file_manager.rec_ofstream() << "DEBUG: lambda list at start of new iteration = ";
+		for (auto val : pest_scenario.get_pestpp_options().get_base_lambda_vec())
+			file_manager.rec_ofstream() << val << " ";
+		file_manager.rec_ofstream() << std::endl;
+
 		int i_update_vec = 0;
 		stringstream message;
 		stringstream prf_message;
@@ -1379,7 +1385,11 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 		}
 	}
 	pest_scenario.get_pestpp_options_ptr()->set_base_lambda_vec(lambda_vec);
-	
+
+	file_manager.rec_ofstream() << "DEBUG: lambda list after extend = ";
+	for (auto val : pest_scenario.get_pestpp_options().get_base_lambda_vec())
+		file_manager.rec_ofstream() << val << " ";
+	file_manager.rec_ofstream() << std::endl;
 	return best_upgrade_run;
 }
 


### PR DESCRIPTION
As discussed in issue https://github.com/usgs/pestpp/issues/346#issue-3029040834, PEST++GLM does not currently expand its list of explored lambdas, which can hamper the calibration process. This PR amends that so that whenever the highest or lowest lambda gives the lowest phi value, a new value is appended onto the list. This is currently hardcoded to 10 times greater than the highest lambda or 10 times less than the lowest lambda. If there is interest, this value can be added as a pestpp option for users to modify.

Additionally, values in the lambda_scale_vec higher than 1 are no longer ignored by GLM. The only exception is a value of exactly 1, as this winds up being a waste (the normal vector length is already tested regardless).

These changes are included in both the SVD and the SVDA solver codes.

(the github issue alludes to some additional changes related to PEST_HP's lambda implementation, but those are not included in this PR).